### PR TITLE
Add body as a callback support to 4.2.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
         "ext-mbstring" : "*",
         "ext-ctype"    : "*",
         "sabre/event"  : ">=1.0.0,<4.0.0",
-        "sabre/uri"    : "~1.0"
+        "sabre/uri"    : "^1.0.1"
     },
     "require-dev" : {
         "phpunit/phpunit" : "~4.3",
-        "sabre/cs" : "~0.0.1"
+        "sabre/cs" : "~0.0.8"
     },
     "suggest" : {
         "ext-curl" : " to make http requests with the Client class"

--- a/lib/Message.php
+++ b/lib/Message.php
@@ -42,19 +42,20 @@ abstract class Message implements MessageInterface {
      * Note that the stream may not be rewindable, and therefore may only be
      * read once.
      *
+     * @throws \RuntimeException
      * @return resource
      */
     function getBodyAsStream() {
 
         $body = $this->getBody();
+        if (is_callable($body)) {
+            $body = $this->captureCallbackOutput($body);
+        }
         if (is_string($body) || is_null($body)) {
             $stream = fopen('php://temp', 'r+');
             fwrite($stream, $body);
             rewind($stream);
             return $stream;
-        }
-        if (is_callable($body)) {
-            throw new \UnexpectedValueException('Callback to stream not supported');
         }
         return $body;
 
@@ -66,6 +67,7 @@ abstract class Message implements MessageInterface {
      * Note that because the underlying data may be based on a stream, this
      * method could only work correctly the first time.
      *
+     * @throws \RuntimeException
      * @return string
      */
     function getBodyAsString() {
@@ -78,7 +80,7 @@ abstract class Message implements MessageInterface {
             return '';
         }
         if (is_callable($body)) {
-            throw new \UnexpectedValueException('Callback to string not supported');
+            return $this->captureCallbackOutput($body);
         }
         $contentLength = $this->getHeader('Content-Length');
         if (is_int($contentLength) || ctype_digit($contentLength)) {
@@ -316,5 +318,24 @@ abstract class Message implements MessageInterface {
 
         return $this->httpVersion;
 
+    }
+
+    /**
+     * Runs given callback and captures data sent to php://output stream.
+     *
+     * @param callable $callback
+     * @throws \RuntimeException when ob_start() fails to start output buffer
+     * @return string
+     */
+    private function captureCallbackOutput($callback)
+    {
+        $success = ob_start();
+        if ($success === false) {
+            throw new \RuntimeException('Cannot start output buffering');
+        }
+        $callback();
+        $content = ob_get_contents();
+        ob_end_clean();
+        return $content;
     }
 }

--- a/lib/Message.php
+++ b/lib/Message.php
@@ -334,8 +334,6 @@ abstract class Message implements MessageInterface {
             throw new \RuntimeException('Cannot start output buffering');
         }
         $callback();
-        $content = ob_get_contents();
-        ob_end_clean();
-        return $content;
+        return ob_get_clean();
     }
 }

--- a/lib/Message.php
+++ b/lib/Message.php
@@ -16,9 +16,9 @@ abstract class Message implements MessageInterface {
     /**
      * Request body
      *
-     * This should be a stream resource
+     * This should be a stream resource, string or a callback writing the body to php://output
      *
-     * @var resource
+     * @var resource|string|callable
      */
     protected $body;
 
@@ -53,6 +53,9 @@ abstract class Message implements MessageInterface {
             rewind($stream);
             return $stream;
         }
+        if (is_callable($body)) {
+            throw new \UnexpectedValueException('Callback to stream not supported');
+        }
         return $body;
 
     }
@@ -74,6 +77,9 @@ abstract class Message implements MessageInterface {
         if (is_null($body)) {
             return '';
         }
+        if (is_callable($body)) {
+            throw new \UnexpectedValueException('Callback to string not supported');
+        }
         $contentLength = $this->getHeader('Content-Length');
         if (is_int($contentLength) || ctype_digit($contentLength)) {
             return stream_get_contents($body, $contentLength);
@@ -85,9 +91,9 @@ abstract class Message implements MessageInterface {
     /**
      * Returns the message body, as it's internal representation.
      *
-     * This could be either a string or a stream.
+     * This could be either a string, a stream or a callback writing the body to php://output.
      *
-     * @return resource|string
+     * @return resource|string|callable
      */
     function getBody() {
 
@@ -96,9 +102,9 @@ abstract class Message implements MessageInterface {
     }
 
     /**
-     * Replaces the body resource with a new stream or string.
+     * Replaces the body resource with a new stream, string or a callback writing the body to php://output.
      *
-     * @param resource|string $body
+     * @param resource|string|callable $body
      */
     function setBody($body) {
 

--- a/lib/Message.php
+++ b/lib/Message.php
@@ -42,7 +42,6 @@ abstract class Message implements MessageInterface {
      * Note that the stream may not be rewindable, and therefore may only be
      * read once.
      *
-     * @throws \RuntimeException
      * @return resource
      */
     function getBodyAsStream() {
@@ -67,7 +66,6 @@ abstract class Message implements MessageInterface {
      * Note that because the underlying data may be based on a stream, this
      * method could only work correctly the first time.
      *
-     * @throws \RuntimeException
      * @return string
      */
     function getBodyAsString() {
@@ -324,15 +322,11 @@ abstract class Message implements MessageInterface {
      * Runs given callback and captures data sent to php://output stream.
      *
      * @param callable $callback
-     * @throws \RuntimeException when ob_start() fails to start output buffer
      * @return string
      */
     private function captureCallbackOutput($callback)
     {
-        $success = ob_start();
-        if ($success === false) {
-            throw new \RuntimeException('Cannot start output buffering');
-        }
+        ob_start();
         $callback();
         return ob_get_clean();
     }

--- a/lib/MessageInterface.php
+++ b/lib/MessageInterface.php
@@ -35,16 +35,16 @@ interface MessageInterface {
     /**
      * Returns the message body, as it's internal representation.
      *
-     * This could be either a string or a stream.
+     * This could be either a string, a stream or a callback writing the body to php://output
      *
-     * @return resource|string
+     * @return resource|string|callable
      */
     function getBody();
 
     /**
      * Updates the body resource with a new stream.
      *
-     * @param resource|string $body
+     * @param resource|string|callable $body
      * @return void
      */
     function setBody($body);

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -71,6 +71,11 @@ class Sapi {
         $body = $response->getBody();
         if (is_null($body)) return;
 
+        if (is_callable($body)) {
+            $body();
+            return;
+        }
+
         $contentLength = $response->getHeader('Content-Length');
         if ($contentLength !== null) {
             $output = fopen('php://output', 'wb');

--- a/tests/HTTP/MessageTest.php
+++ b/tests/HTTP/MessageTest.php
@@ -87,7 +87,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
      * The request object should make sure to never emit more than
      * Content-Length, if Content-Length is set.
      *
-     * This is in particular useful when respoding to range requests with
+     * This is in particular useful when responding to range requests with
      * streams that represent files on the filesystem, as it's possible to just
      * seek the stream to a certain point, set the content-length and let the
      * request object do the rest.
@@ -247,11 +247,11 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
         $message->addHeader('A', '2');
 
         $this->assertEquals(
-            "1,2",
+            '1,2',
             $message->getHeader('A')
         );
         $this->assertEquals(
-            "1,2",
+            '1,2',
             $message->getHeader('a')
         );
 

--- a/tests/HTTP/MessageTest.php
+++ b/tests/HTTP/MessageTest.php
@@ -285,9 +285,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
     private function createCallback($content)
     {
         return function() use ($content) {
-            $fd = fopen('php://output', 'r+');
-            fwrite($fd, $content);
-            fclose($fd);
+            echo $content;
         };
     }
 

--- a/tests/HTTP/MessageTest.php
+++ b/tests/HTTP/MessageTest.php
@@ -42,42 +42,40 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     */
     function testCallbackBodyAsString() {
 
-        $body = $this->createCallback();
+        $body = $this->createCallback('foo');
 
         $message = new MessageMock();
         $message->setBody($body);
 
-        $message->getBodyAsString();
+        $string = $message->getBodyAsString();
+
+        $this->assertSame('foo', $string);
 
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     */
     function testCallbackBodyAsStream() {
 
-        $body = $this->createCallback();
+        $body = $this->createCallback('foo');
 
         $message = new MessageMock();
         $message->setBody($body);
 
-        $message->getBodyAsStream();
+        $stream = $message->getBodyAsStream();
+
+        $this->assertSame('foo', stream_get_contents($stream));
 
     }
 
     function testGetBodyWhenCallback() {
 
-        $body = $this->createCallback();
+        $callback = $this->createCallback('foo');
 
         $message = new MessageMock();
-        $message->setBody($body);
+        $message->setBody($callback);
 
-        $this->assertEquals($body, $message->getBody());
+        $this->assertSame($callback, $message->getBody());
 
     }
 
@@ -280,11 +278,15 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 
     }
 
-    private function createCallback()
+    /**
+     * @param string $content
+     * @return \Closure Returns a callback printing $content to php://output stream
+     */
+    private function createCallback($content)
     {
-        return function() {
+        return function() use ($content) {
             $fd = fopen('php://output', 'r+');
-            fwrite($fd, 'foo');
+            fwrite($fd, $content);
             fclose($fd);
         };
     }

--- a/tests/HTTP/MessageTest.php
+++ b/tests/HTTP/MessageTest.php
@@ -43,6 +43,45 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @expectedException \UnexpectedValueException
+     */
+    function testCallbackBodyAsString() {
+
+        $body = $this->createCallback();
+
+        $message = new MessageMock();
+        $message->setBody($body);
+
+        $message->getBodyAsString();
+
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     */
+    function testCallbackBodyAsStream() {
+
+        $body = $this->createCallback();
+
+        $message = new MessageMock();
+        $message->setBody($body);
+
+        $message->getBodyAsStream();
+
+    }
+
+    function testGetBodyWhenCallback() {
+
+        $body = $this->createCallback();
+
+        $message = new MessageMock();
+        $message->setBody($body);
+
+        $this->assertEquals($body, $message->getBody());
+
+    }
+
+    /**
      * It's possible that streams contains more data than the Content-Length.
      *
      * The request object should make sure to never emit more than
@@ -239,6 +278,15 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
         $message->setHeader('X-Foo', 'Bar');
         $this->assertTrue($message->hasHeader('X-Foo'));
 
+    }
+
+    private function createCallback()
+    {
+        return function() {
+            $fd = fopen('php://output', 'r+');
+            fwrite($fd, 'foo');
+            fclose($fd);
+        };
     }
 
 }

--- a/tests/HTTP/SapiTest.php
+++ b/tests/HTTP/SapiTest.php
@@ -164,4 +164,25 @@ class SapiTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    /**
+     * @runInSeparateProcess
+     * @depends testSend
+     */
+    function testSendWorksWithCallbackAsBody() {
+        $response = new Response(200, [], function() {
+            $fd = fopen('php://output', 'r+');
+            fwrite($fd, 'foo');
+            fclose($fd);
+        });
+
+        ob_start();
+
+        Sapi::sendResponse($response);
+
+        $result = ob_get_clean();
+
+        $this->assertEquals('foo', $result);
+
+    }
+
 }


### PR DESCRIPTION
Brings Petr's changes from https://github.com/sabre-io/http/pull/65 into a branch based off the 4.2.4 release.

It also brings in this commit which bumps the dependencies - https://github.com/bigcommerce-labs/sabre-http/commit/4b6fef9d1af3801c84195ff11bf5be951e23b602

We currently have all these changes in the custom tag 4.2.1.2 - https://github.com/bigcommerce-labs/sabre-http/releases/tag/4.2.1.2.

I've re-authored the commits to keep them as the head of the branch.

Updating this component will bring us a much needed fix - https://github.com/sabre-io/http/pull/73 - which should resolve - https://rpm.newrelic.com/accounts/44889/applications/4757985/traced_errors/4dca0f16-5188-11e8-b482-0242ac11000f_18714_21831 - which has the highest number of reported errors on production.

https://jira.bigcommerce.com/browse/BIG-30701

This will also allow us to bring the main sabre/dav library up to date (we're also running a custom tag which also has changes from Petr).